### PR TITLE
Add KDE 5 Konsole install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Monokai Colorscheme
 
 #### KDE Konsole
 
-1. Copy the Konsole colorscheme (*.colorscheme) files to ~/.kde/share/apps/konsole/.
+1. Copy the Konsole colorscheme (*.colorscheme) files to (KDE 4) ~/.kde/share/apps/konsole/ or (KDE 5) ~/.local/share/konsole/.
 2. Open Konsole and select Settings => Configure Profiles => Edit Profile => Appearance.
 3. Select the Monokai scheme file and save.
 


### PR DESCRIPTION
Just added the install path for Konsole on KDE 5. Your repo is the first one on a "monokai konsole" google search, this may be useful for others (I got a bit lost, tried using the old path :smile:).